### PR TITLE
Add Jest tests for passport parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "passport-reader-ai",
+  "version": "1.0.0",
+  "description": "An open-source AI-powered passport reading system that extracts data from passport images in seconds. Built to solve real-world document processing challenges faced by consulates and government offices.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/src/js/__tests__/passport-parser.test.js
+++ b/src/js/__tests__/passport-parser.test.js
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+describe('PassportParser', () => {
+  beforeAll(() => {
+    require('../passport-parser');
+  });
+
+  test('parses MRZ lines for male traveler', () => {
+    const parser = new window.PassportParser();
+    const mrz = `P<MNGDOE<<JOHN<<<<<<<<<<<<<<<<<<<<<<\nE<012345678MNG8001011M2501012<<<<<<<<<<<<<<04`;
+    const result = parser.parseText(mrz);
+
+    expect(result.fullName).toBe('JOHN DOE');
+    expect(result.passportNumber).toBe('E012345678');
+    expect(result.dateOfBirth).toBe('01/01/1980');
+    expect(result.expiryDate).toBe('01/01/2025');
+  });
+
+  test('parses MRZ lines for female traveler', () => {
+    const parser = new window.PassportParser();
+    const mrz = `P<MNGSMITH<<JANE<<<<<<<<<<<<<<<<<<<<\nE<987654321MNG8502022F3002023<<<<<<<<<<<<<<08`;
+    const result = parser.parseText(mrz);
+
+    expect(result.fullName).toBe('JANE SMITH');
+    expect(result.passportNumber).toBe('E987654321');
+    expect(result.dateOfBirth).toBe('02/02/1985');
+    expect(result.expiryDate).toBe('02/02/2030');
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest test infrastructure
- add tests verifying MRZ parsing for names, passport numbers, and dates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cec8f753c832bbb5a9571d9c428ed